### PR TITLE
Add option to keep prefix operators even in noop cases

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ export interface Token {
 
 export interface Options {
   language?: 'en-US' | 'de-DE';
+  keepPrefixOperators: boolean;
 }
 
 declare function tokenize(str: string, options?: Options): Token[];

--- a/index.js
+++ b/index.js
@@ -161,6 +161,7 @@ class TokenStack {
  * @param {string} [options.language] - Defaults to en-US
  * @param {boolean} [options.preserveLanguage] - Defaults to false. When true language specific characters will be written to the token output instead of being normalized.
  * @param {boolean} [options.asClass] - Defaults to false. When true tokenize will reutrn the instantiated Tokens class instead of calling Tokens.toArray().
+ * @param {boolean} [options.keepPrefixOperators] - Defaults to false. When true prefix operators will be kept in the token output.
  * @returns {Token[]|Tokens} - If options.asClass is true then the Tokens class gets return. Otherwise this returns an array of Token objects.
  */
 function tokenize(formula, options) {
@@ -596,7 +597,7 @@ function tokenize(formula, options) {
 
     if (token.type == TOK_TYPE_OP_IN && token.value == '+') {
       if (tokens2.BOF()) {
-        token.type = TOK_TYPE_NOOP;
+        token.type = options.keepPrefixOperators ? TOK_TYPE_OP_PRE : TOK_TYPE_NOOP;
       } else if (
         (tokens2.previous().type == TOK_TYPE_FUNCTION && tokens2.previous().subtype == TOK_SUBTYPE_STOP) ||
         (tokens2.previous().type == TOK_TYPE_SUBEXPR && tokens2.previous().subtype == TOK_SUBTYPE_STOP) ||


### PR DESCRIPTION
Some Excel users start formulas always with a `=+` and thus, being able to have an option to keep even `noop` prefixes would be nice. E.g., in a formula like `=+SUM(H8:H11)+-H12+(-H13)`.